### PR TITLE
Add a timeout to the Tag read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+app/build/**
+.gradle/**
+.idea/**
+local.properties
+*.bat
+gradlew
+gradle/wrapper/gradle-wrapper.properties
+gradle/wrapper/gradle-wrapper.jar
+build/intermediates/dex-cache/cache.xml
+build.gradle
+build.gradle
+app/app.iml
+app/src/main/res/values/strings.xml

--- a/app/src/main/java/com/yubichallenge/NFCActivity.java
+++ b/app/src/main/java/com/yubichallenge/NFCActivity.java
@@ -96,6 +96,7 @@ public class NFCActivity extends Activity {
 			IsoDep isoTag = IsoDep.get(tag);
 			try {
 				isoTag.connect();
+				isoTag.setTimeout(30000);
 				byte[] resp = isoTag.transceive(selectCommand);
 				int length = resp.length;
 				if (resp[length - 2] == (byte) 0x90 && resp[length - 1] == 0x00)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">YubiChallengeLA</string>
+    <string name="app_name">YubiChallenge</string>
     <string name="info">This app provides a simple interface for using the NFC challenge-response functionality built into a Yubikey Neo. It will be started by a 3rd party app such as keepass2android when necessary. It is provided as a standalone app so that the majority of users who do not own a Yubikey do not have to grant NFC permissions unnecessarily.</string>
     <string name="action_settings">Settings</string>
     <string name="title_activity_nfc">NFC Challenge-Response</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">YubiChallenge</string>
+    <string name="app_name">YubiChallengeLA</string>
     <string name="info">This app provides a simple interface for using the NFC challenge-response functionality built into a Yubikey Neo. It will be started by a 3rd party app such as keepass2android when necessary. It is provided as a standalone app so that the majority of users who do not own a Yubikey do not have to grant NFC permissions unnecessarily.</string>
     <string name="action_settings">Settings</string>
     <string name="title_activity_nfc">NFC Challenge-Response</string>

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
     }
 }
 


### PR DESCRIPTION
On my device, this corrected the error when the tag could not be read.  Now seems to work everytime.